### PR TITLE
Add packaging for Meteor.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 libs/
 !libs/jquery-loader.js
+.build*

--- a/meteor/package.js
+++ b/meteor/package.js
@@ -1,0 +1,23 @@
+var fs = Npm.require('fs');
+var packageJson = JSON.parse(fs.readFileSync('vide.jquery.json'));
+var packageName = 'vodkabears:vide';
+var where = 'client';
+
+Package.describe({
+    git: 'https://github.com/VodkaBears/Vide',
+    name: packageName,
+    summary: 'Easy as hell jQuery plugin for video backgrounds',
+    version: packageJson.version
+});
+
+Package.onUse(function(api) {
+    api.versionsFrom('1.0');
+    api.use('jquery', where);
+    api.addFiles('dist/jquery.vide.js', where);
+});
+
+Package.onTest(function(api) {
+    api.use(packageName, where);
+    api.use('tinytest', where);
+    api.addFiles('meteor/test.js', where);
+});

--- a/meteor/publish.sh
+++ b/meteor/publish.sh
@@ -1,0 +1,23 @@
+# Publish package on Meteor's Atmosphere.js
+
+# Make sure Meteor is installed, per https://www.meteor.com/install. The curl'ed script is totally safe; takes 2 minutes to read its source and check.
+type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }
+
+# sanity check: make sure we're in the root directory of the checkout
+DIR=$( cd "$( dirname "$0" )" && pwd )
+cd $DIR/..
+
+# Meteor expects package.js to be in the root directory of the checkout, so copy it there temporarily
+cp meteor/package.js ./
+
+# publish package, creating it if it's the first time we're publishing
+PACKAGE_NAME=$(grep -i name package.js | head -1 | cut -d "'" -f 2)
+PACKAGE_EXISTS=$(meteor search $PACKAGE_NAME 2>/dev/null | wc -l)
+
+if [ $PACKAGE_EXISTS -gt 0 ]; then
+    meteor publish
+else
+    meteor publish --create
+fi
+
+rm package.js

--- a/meteor/runtests.sh
+++ b/meteor/runtests.sh
@@ -1,0 +1,28 @@
+# Test Meteor package before publishing to Atmosphere.js
+
+# Make sure Meteor is installed, per https://www.meteor.com/install. The curl'ed script is totally safe; takes 2 minutes to read its source and check.
+type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }
+
+# sanity check: make sure we're in the root directory of the checkout
+DIR=$( cd "$( dirname "$0" )" && pwd )
+cd $DIR/..
+
+# Meteor expects package.js to be in the root directory of the checkout, so copy it there temporarily
+cp meteor/package.js ./
+
+# run tests and delete the temporary package.js even if Ctrl+C is pressed
+int_trap() {
+    echo
+    echo "Tests interrupted."
+}
+
+trap int_trap INT
+
+meteor test-packages ./
+
+PACKAGE_NAME=$(grep -i name package.js | head -1 | cut -d "'" -f 2)
+rm -rf ".build.$PACKAGE_NAME"
+rm -rf ".build.local-test:$PACKAGE_NAME"
+rm versions.json 2>/dev/null
+
+rm package.js

--- a/meteor/test.js
+++ b/meteor/test.js
@@ -1,0 +1,5 @@
+'use strict';
+
+Tinytest.add('Instantiation', function(test) {
+    test.notEqual(jQuery().vide, undefined);
+});


### PR DESCRIPTION
In an effort from the Meteor.js community to try and keep wrapped packages to a minimum we are trying to get support for meteor packages into the official repositories.

This PR provides an easy way to publish your plugin as a meteor package, making my wrapper package unnecessary. =)

What's needed from you part is to go to meteor.com and register for a developer account. If you don't want to use vodkabears as your username then I would suggest you add an organization named vodkabears after you create you account. If you for some reason don't
want to use vodkabears as your namespace for the package, I added an organization called vide just in case, which I will happily add you to once you have a developer account.

If you don't want to use vodkabears as the namespace for the package you will have to update this line
https://github.com/zimme/Vide/blob/meteor-integration/meteor/package.js#L3
to match the package "namespace:name" you want to use as this is the naming convention for meteor packages.
