### PR TITLE
Added poster to help avoid empty spaces in IE

### DIFF
--- a/src/jquery.vide.js
+++ b/src/jquery.vide.js
@@ -169,7 +169,9 @@
       loop: vide.settings.loop,
       volume: vide.settings.volume,
       muted: vide.settings.muted,
-      playbackRate: vide.settings.playbackRate
+      playbackRate: vide.settings.playbackRate,
+      preload: 'none',
+      poster: vide.path + '.jpg',
     });
   }
 


### PR DESCRIPTION
We had an issue in IE where during loading it was just showing empty space (not the poster image). This prevents that. I just hope that the way I have written it is correct – I notice that there is a check for `typeof(path)` – this just assumes that `path` is a string.

D
