### PR TITLE
Allow custom background-color in Vide div

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Below is a complete list of options and matching default values:
   autoplay: true,
   position: '50% 50%', // Similar to the CSS `background-position` property.
   posterType: 'detect', // Poster image type. "detect" — auto-detection; "none" — no poster; "jpg", "png", "gif",... - extensions.
-  resizing: true // Auto-resizing, read: https://github.com/VodkaBears/Vide#resizing
+  resizing: true, // Auto-resizing, read: https://github.com/VodkaBears/Vide#resizing
+  backgroundColor: 'transparent' // Allow custom background-color for Vide div
 }
 ```
 

--- a/src/jquery.vide.js
+++ b/src/jquery.vide.js
@@ -32,7 +32,8 @@
     autoplay: true,
     position: '50% 50%',
     posterType: 'detect',
-    resizing: true
+    resizing: true,
+    backgroundColor: 'transparent'
   };
 
   /**
@@ -227,6 +228,7 @@
     var settings = vide.settings;
     var position = parsePosition(settings.position);
     var posterType = settings.posterType;
+    var backgroundColor = settings.backgroundColor;
     var $video;
     var $wrapper;
 
@@ -261,6 +263,9 @@
         }
       }
     }
+
+    // Set a background color
+    $wrapper.css('background-color', backgroundColor);
 
     // Set a video poster
     if (posterType === 'detect') {

--- a/test/vide_test.js
+++ b/test/vide_test.js
@@ -66,6 +66,7 @@
     strictEqual(inst.settings.position, '50% 50%');
     strictEqual(inst.settings.posterType, 'detect');
     strictEqual(inst.settings.resizing, true);
+    strictEqual(inst.settings.backgroundColor, 'transparent');
   });
 
   QUnit.test('Parsing of the path', function() {


### PR DESCRIPTION
The text overtop of our Vide video background was white. We had a case where the browser failed to load the video and poster files from s3 (s3 was down? who knows), and so the section was white-on-white (users could not find the sign-up buttons, etc). 

This PR allows a background-color to be used, which allows the text to show up even if video assets fail to load.