### PR TITLE
Add comment to clarify when getVideoObject works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Below is a complete list of methods:
 var instance = $('#yourElement').data('vide');
 
 // Get video element of the background. Do what you want.
+// You'll need to initialize vide via JS for this to work.
 instance.getVideoObject();
 
 // Resize video background.


### PR DESCRIPTION
I've been playing with this all morning, and realized getVideoObject() seems to only work when I initialize vide via JS and not via html attributes. I'm guessing this is related to the earlier advice in the readme that js initialization is required to use mutation observers.

Thanks for the awesome library!
