### PR TITLE
Remove deprecated jQuery load method, fix jQuery 3 compatibility

### DIFF
--- a/src/jquery.vide.js
+++ b/src/jquery.vide.js
@@ -164,10 +164,10 @@
       callback(this.src);
     };
 
-    $('<img src="' + path + '.gif">').load(onLoad);
-    $('<img src="' + path + '.jpg">').load(onLoad);
-    $('<img src="' + path + '.jpeg">').load(onLoad);
-    $('<img src="' + path + '.png">').load(onLoad);
+    $('<img src="' + path + '.gif">').on('load', onLoad);
+    $('<img src="' + path + '.jpg">').on('load', onLoad);
+    $('<img src="' + path + '.jpeg">').on('load', onLoad);
+    $('<img src="' + path + '.png">').on('load', onLoad);
   }
 
   /**


### PR DESCRIPTION
.load was deprecated in jQuery 3. Fixing this seems to get the plugin working while still maintaining compatibility with jQuery 2.

See https://blog.jquery.com/2015/07/13/jquery-3-0-and-jquery-compat-3-0-alpha-versions-released/.

Fix for https://github.com/VodkaBears/Vide/issues/183.